### PR TITLE
corrected src__addr.nl_family = AF_NETLINK; to src_addr.nl_family = A…

### DIFF
--- a/articles/Why_and_How_to_Use_Netlink_Socket.md
+++ b/articles/Why_and_How_to_Use_Netlink_Socket.md
@@ -276,7 +276,7 @@ void main() {
   sock_fd = socket(PF_NETLINK, SOCK_RAW, NETLINK_TEST);
 
   memset(&src_addr, 0, sizeof(src_addr));
-  src__addr.nl_family = AF_NETLINK;
+  src_addr.nl_family = AF_NETLINK;
   src_addr.nl_pid = getpid();  /* self pid */
   src_addr.nl_groups = 0;  /* not in mcast groups */
   bind(sock_fd, (struct sockaddr*)&src_addr,


### PR DESCRIPTION
…F_NETLINK;

corrected src__addr.nl_family = AF_NETLINK; to src_addr.nl_family = AF_NETLINK;